### PR TITLE
chore: update renovate config to use github repository reference

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,4 @@
 {
-  "extends": ["@berlysia", ":pinDevDependencies"],
+  "extends": ["github>berlysia/renovate-config", ":pinDevDependencies"],
   "ignoreDeps": ["eslint-config-flat-gitignore"]
 }


### PR DESCRIPTION
Update deprecated `extends: @berlysia` to `extends: github>berlysia/renovate-config`

This change updates the Renovate configuration to use the GitHub repository reference instead of the deprecated npm package reference.